### PR TITLE
Improve Docker builds with single-arch target and GitHub cache backend

### DIFF
--- a/.github/workflows/ci_cd_pipeline.yml
+++ b/.github/workflows/ci_cd_pipeline.yml
@@ -53,9 +53,13 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
           platforms: linux/amd64
-          tags: temp/test-image:pr-${{ github.sha }}
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max #    ^
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
 
   # Build + Push
   build:
@@ -86,13 +90,13 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64
           push: true
-          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to:   type=gha,mode=max
           tags: |
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ github.sha }}
-          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
-          cache-to:   type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
 
   # Deploy
   deploy:


### PR DESCRIPTION
Using Github cache over google cloud cache should be faster, and single-arch will be faster and is what google cloud run uses anyways.