### PR TITLE
Lifespan changes

### DIFF
--- a/backend-api/src/database.py
+++ b/backend-api/src/database.py
@@ -1,5 +1,4 @@
 import contextlib
-import ssl
 
 from typing import Any, AsyncIterator
 from uuid import uuid4
@@ -20,9 +19,13 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from fastapi import Request
+
+
 # Base class for all ORM models (Helps with Lazy Loading)
 class Base(AsyncAttrs, DeclarativeBase):
     pass
+
 
 class DatabaseSessionManager:
     """
@@ -40,22 +43,25 @@ class DatabaseSessionManager:
         is_postgres = url_obj.drivername.startswith("postgresql")
 
         if is_postgres:
-            # TODO: Create an SSL context for asyncpg 
+            # TODO: Create an SSL context for asyncpg
             # ssl_context = ssl.create_default_context()
             # connect_args = {"ssl": ssl_context}
 
-            # 
             connect_args = {
-                "ssl": False, 
+                "ssl": False,
                 "statement_cache_size": 0,  # Disable asyncpg prepared statement cache
+                "prepared_statement_cache_size": 0,
                 "prepared_statement_name_func": lambda: f"__asyncpg_{uuid4()}__",
-                }
+                "server_settings": {
+                    "statement_timeout": "3000",  # Optional: Set statement timeout
+                },
+            }
         else:
             connect_args = {}
 
         self._engine = create_async_engine(
             db_url,
-            poolclass=NullPool, # Optional: disables SQLAlchemy connection pool, relying on Supavisor (From SupaBase)
+            poolclass=NullPool,  # Optional: disables SQLAlchemy connection pool, relying on Supavisor (From SupaBase)
             connect_args=connect_args,
             **engine_kwargs,
         )
@@ -103,26 +109,24 @@ class DatabaseSessionManager:
             await session.close()
 
 
-# NOTE: DataBase (Postgres) is async compatible
-# Load SUPABASE_DB_URL from environment variable
-SUPABASE_DB_URL = get_settings().SUPABASE_DB_URL
-
-# Create global session manager instance
-sessionmanager = DatabaseSessionManager(SUPABASE_DB_URL)
-
-
 # FastAPI dependency for Endpoints
-async def get_db_session() -> AsyncIterator[AsyncSession]:
+async def get_db_session(request: Request) -> AsyncIterator[AsyncSession]:
     """Dependency that yields a database session"""
-    async with sessionmanager.session() as session:
+    async with request.app.state.session_manager.session() as session:
         yield session
 
+
 # Creates an async Redis Client
-def init_redis():
-    return Redis(
+async def init_redis():
+    redis = await Redis(
         host="redis-13649.crce199.us-west-2-2.ec2.redns.redis-cloud.com",
         port=13649,
         decode_responses=True,
         username="default",
         password=get_settings().REDIS_PASSWORD,
+        socket_timeout=5,  # Prevents hanging forever
+        socket_connect_timeout=5,
     )
+    await redis.ping()
+
+    return redis

--- a/backend-api/src/main.py
+++ b/backend-api/src/main.py
@@ -1,33 +1,51 @@
-from contextlib import asynccontextmanager # Used to manage async app startup/shutdown events
+import asyncio
+import logging
+from contextlib import asynccontextmanager  # Used to manage async app startup/shutdown events
 
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware # Enables frontend-backend communications via CORS
+from fastapi.middleware.cors import CORSMiddleware  # Enables frontend-backend communications via CORS
 
-from src.database import sessionmanager, Base, init_redis
-
+# Need to import the models in the same module that Base is defined to ensure they are registered with SQLAlchemy
 from src.auth import models  # noqa
 from src.llm import models  # noqa
 
 from src.admin.router import router as admin_router
 from src.auth.router import router as auth_router
 from src.llm.router import router as llm_router
-from src.middleware import RateLimitMiddleware # Custom middleware for rate limiting
+from src.database import Base, DatabaseSessionManager, init_redis
+from src.middleware import RateLimitMiddleware  # Custom middleware for rate limiting
+from src.settings import get_settings  # Settings management for environment variables
+
+
+logger = logging.getLogger("uvicorn.error")
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Create tables on startup using async engine
-    async with sessionmanager._engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
 
-    # Initialize Redis Client
-    app.state.redis_client = init_redis()
-    
-    yield
-    # Close connection to database and Redis Connection
-    # TODO? Add try/except if an exception prevents cleanup
-    await sessionmanager.close()
-    await app.state.redis_client.aclose()
+    # Create tables on startup using async engine
+    try:
+        async with asyncio.timeout(20):
+            logger.info("Initializing database session manager...")
+            session_manager = DatabaseSessionManager(get_settings().SUPABASE_DB_URL)
+            app.state.session_manager = session_manager
+            assert session_manager._engine is not None, "Session manager engine is not initialized"
+            async with session_manager._engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+        # Initialize Redis client
+        async with asyncio.timeout(20):
+            logger.info("Initializing Redis client...")
+            app.state.redis_client = await init_redis()
+
+        yield
+    finally:
+        # Close connection to database and Redis Connection
+        if hasattr(app.state, "session_manager"):
+            logger.info("Closing database session manager...")
+            await app.state.session_manager.close()
+        if hasattr(app.state, "redis_client"):
+            logger.info("Closing Redis client...")
+            await app.state.redis_client.aclose()
 
 
 def create_app():
@@ -53,5 +71,10 @@ def create_app():
 
     return app
 
+
 app = create_app()
 
+
+@app.get("/health")
+async def health_check():
+    return {"status": "ok"}

--- a/backend-api/src/main.py
+++ b/backend-api/src/main.py
@@ -29,7 +29,8 @@ async def lifespan(app: FastAPI):
             logger.info("Initializing database session manager...")
             session_manager = DatabaseSessionManager(get_settings().SUPABASE_DB_URL)
             app.state.session_manager = session_manager
-            assert session_manager._engine is not None, "Session manager engine is not initialized"
+            if session_manager._engine is None:
+                raise RuntimeError("Session manager engine is not initialized")
             async with session_manager.connect() as conn:
                 await conn.run_sync(Base.metadata.create_all)
         # Initialize Redis client

--- a/backend-api/src/main.py
+++ b/backend-api/src/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             session_manager = DatabaseSessionManager(get_settings().SUPABASE_DB_URL)
             app.state.session_manager = session_manager
             assert session_manager._engine is not None, "Session manager engine is not initialized"
-            async with session_manager._engine.begin() as conn:
+            async with session_manager.connect() as conn:
                 await conn.run_sync(Base.metadata.create_all)
         # Initialize Redis client
         async with asyncio.timeout(20):


### PR DESCRIPTION
- create session manager in lifespan instead of global. 
- add logging to lifespan. 
- add async timeouts to catch hanging processes.
- added other timeouts to all db requests and redis requests, since an assertion in the container would be better than the request never finishing.

When running locally with these changes, I have not yet had that hang error where an api request seems to run forever. Shutdown seems more consistent, but there have been a couple times still where the db init step in lifespan will timeout. After retrying a couple of times, the init step would succeed.