### PR TITLE
fix bug where redis entry could have no expire time

### DIFF
--- a/backend-api/src/middleware.py
+++ b/backend-api/src/middleware.py
@@ -15,8 +15,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self.max_requests = max_requests  # Max allowed requests in time window
 
     async def permit_request(self, redis: Redis, key: str):
-        if await redis.setnx(key, self.max_requests):
-            await redis.expire(key, self.window_sec)
+        # If the ip does not exist in the cache, add it with the value of max_requests
+        # and set the expiration time to window_sec
+        await redis.set(key, self.max_requests, ex=self.window_sec, nx=True)
         cache_val: Optional[bytes] = await redis.get(key)
 
         # Fetch current number of requests remaining


### PR DESCRIPTION
- there was a small amount of time after a key had been added to the redis cache where it didn't have an expiry time.
- if the app was shutdown during this time, the key would live forever in the cache, forever blocking that ip with the rate limit