### PR TITLE
Reduce docker memory usage - revert hdbscan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,3 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY ./backend-api ./backend-api
 
 CMD ["uvicorn", "src.main:app", "--app-dir", "backend-api", "--host", "0.0.0.0", "--port", "8080"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,6 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
-    build-essential \
-    gcc \
-    g++ \
-    libomp-dev \
-    python3-dev \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/backend-api/src/admin/router.py
+++ b/backend-api/src/admin/router.py
@@ -4,10 +4,6 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
-from sentence_transformers import SentenceTransformer
-import hdbscan
-import numpy as np
-from collections import defaultdict
 
 # Dependencies
 from src.database import get_db_session
@@ -21,44 +17,10 @@ router = APIRouter()
 
 @router.get("/messages")
 async def get_all_messages(
-    _: Annotated[UserOut, Depends(get_admin_user)], 
-    db: Annotated[AsyncSession, Depends(get_db_session)]
+    _: Annotated[UserOut, Depends(get_admin_user)], db: Annotated[AsyncSession, Depends(get_db_session)]
 ) -> List[schemas.Message]:
     """Get all messages"""
     # TODO: add pagination to this in case there are tons of messages
-    
-    result = await db.execute(
-        select(models.Message).order_by(models.Message.message_id.desc())
-    )
+
+    result = await db.execute(select(models.Message).order_by(models.Message.message_id.desc()))
     return result.scalars().all()  # type: ignore
-
-
-@router.get("/messages/clustered")
-async def get_clustered_messages(
-        _: Annotated[UserOut, Depends(get_admin_user)],
-        db: Annotated[AsyncSession, Depends(get_db_session)],
-):
-    """Cluster all message inputs using HDBSCAN"""
-    # fetch messages
-    result = await db.execute(select(models.Message))
-    messages = result.scalars().all()
-
-    if not messages:
-        return {}
-
-    inputs = [m.input for m in messages]
-
-    # embed inputs
-    model = SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2')
-    embeddings = model.encode(inputs, convert_to_numpy=True, show_progress_bar=False)
-
-    # cluster with hdbscan
-    clusterer = hdbscan.HDBSCAN(min_cluster_size=3, min_samples=2, metric='euclidean')
-    labels = clusterer.fit_predict(embeddings)
-
-    # organize clusters into json and output
-    clusters = defaultdict(list)
-    for msg, label in zip(messages, labels):
-        clusters[str(label)].append(msg.input)
-
-    return dict(clusters)

--- a/backend-api/test/test_admin.py
+++ b/backend-api/test/test_admin.py
@@ -1,89 +1,15 @@
 import pytest
 from httpx import AsyncClient
 from fastapi import status
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from typing import List
-
-from src.auth.models import User
-from src.llm import schemas
-from src.llm.models import Conversation, Message
 
 @pytest.mark.asyncio
 async def test_admin_endpoint_unauthenticated(client: AsyncClient):
     response = await client.get("/admin/messages")
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
+
 @pytest.mark.asyncio
 async def test_admin_endpoint_as_user(client: AsyncClient, user_headers):
     response = await client.get("/admin/messages", headers=user_headers)
     assert response.status_code == status.HTTP_403_FORBIDDEN
-
-@pytest.mark.asyncio
-async def test_admin_endpoint_as_admin(client: AsyncClient, async_session: AsyncSession, admin_headers):
-    # add 2 users
-    user1 = User(username="user1", hashed_password="hpw1", onc_token="token1")
-    user2 = User(username="user2", hashed_password="hpw2", onc_token="token2")
-    async_session.add_all([user1, user2])
-    await async_session.commit()
-    await async_session.refresh(user1)
-    await async_session.refresh(user2)
-
-    # add 2 conversations
-    conv1 = Conversation(user=user1, title="conv 1")
-    conv2 = Conversation(user=user2, title="conv 2")
-    async_session.add_all([conv1, conv2])
-    await async_session.commit()
-    await async_session.refresh(conv1)
-    await async_session.refresh(conv2)
-
-    # add 2 messages
-    message1 = Message(conversation=conv1, user_id=user1.id, input="hello from 1", response="response 1")
-    message2 = Message(conversation=conv2, user_id=user2.id, input="hello from 2", response="response 2")
-    async_session.add_all([message1, message2])
-    await async_session.commit()
-    await async_session.refresh(message1)
-    await async_session.refresh(message2)
-
-    response = await client.get("/admin/messages", headers=admin_headers)
-    assert response.status_code == 200
-    data: List = response.json()
-    assert len(data) == 2
-    # recent messages first
-    assert schemas.Message.model_validate(data[0]).conversation_id == message2.conversation_id
-    assert schemas.Message.model_validate(data[1]).conversation_id == message1.conversation_id
-
-
-@pytest.mark.asyncio
-async def test_clustered_messages_returns_valid_json(client: AsyncClient, async_session: AsyncSession, admin_headers):
-    # add 2 users
-    user1 = User(username="user1", hashed_password="hpw1", onc_token="token1")
-    user2 = User(username="user2", hashed_password="hpw2", onc_token="token2")
-    async_session.add_all([user1, user2])
-    await async_session.commit()
-    await async_session.refresh(user1)
-    await async_session.refresh(user2)
-
-    # add 2 conversations
-    conv1 = Conversation(user=user1, title="conv 1")
-    conv2 = Conversation(user=user2, title="conv 2")
-    async_session.add_all([conv1, conv2])
-    await async_session.commit()
-    await async_session.refresh(conv1)
-    await async_session.refresh(conv2)
-
-    # add 2 messages
-    message1 = Message(conversation=conv1, user_id=user1.id, input="hello from 1", response="response 1")
-    message2 = Message(conversation=conv2, user_id=user2.id, input="hello from 2", response="response 2")
-
-    async_session.add_all([message1, message2])
-    await async_session.commit()
-    await async_session.refresh(message1)
-    await async_session.refresh(message2)
-
-    response = await client.get("/admin/messages/clustered", headers=admin_headers)
-
-    assert response.status_code == 200
-    clusters = response.json()
-    assert isinstance(clusters, dict)
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,18 @@
 services:
-  backend:
-    build: .
-    ports:
-      - "8000:8000"
+    backend:
+        build: .
+        ports:
+            - "8000:8080"
+        env_file:
+            - ./backend-api/.env
+        environment:
+            - PYTHONPATH=/app
+        restart: no
+        stop_grace_period: 10s # let FastAPI shut down cleanly
+        healthcheck:
+            test:
+                ["CMD-SHELL", "curl -fs http://localhost:8080/health || exit 1"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+            start_period: 40s

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,6 @@ groq==0.25.0
 grpcio==1.71.0
 h11==0.16.0
 h2==4.2.0
-hdbscan==0.8.40
 hpack==4.1.0
 httpcore==1.0.9
 httptools==0.6.4


### PR DESCRIPTION
docker container was running with 460+ mb of memory and hitting memory limits on google cloud. after reverting the hdbscan changes, container runs with 60mb.

also adding the db pool changes suggested by simran since those have not yet been tested in deployment.