### PR TITLE
Add production environment variable handling in CI/CD pipeline and Environment class

### DIFF
--- a/.github/workflows/ci_cd_pipeline.yml
+++ b/.github/workflows/ci_cd_pipeline.yml
@@ -123,6 +123,7 @@ jobs:
           flags: |
             --allow-unauthenticated
           env_vars: |
+            ENV=production
             SUPABASE_DB_URL: "${{ secrets.SUPABASE_DB_URL }}"
             SECRET_KEY=${{ vars.SECRET_KEY }}
             ALGORITHM=${{ vars.ALGORITHM }}

--- a/LLM/Environment.py
+++ b/LLM/Environment.py
@@ -6,8 +6,11 @@ from pathlib import Path
 
 class Environment:
     def __init__(self):
-        env_file_location = str(Path(__file__).resolve().parent.parent / ".env")
-        load_dotenv(env_file_location)
+        # If we're in production, we assume environment variables are set
+        # If not, we load them from a .env file
+        if os.getenv("ENV") != "production":
+            env_file_location = str(Path(__file__).resolve().parent / ".env")
+            load_dotenv(env_file_location)
         self.onc_token = os.getenv("ONC_TOKEN")
         self.location_code = os.getenv("CAMBRIDGE_LOCATION_CODE")
         self.model = "llama-3.3-70b-versatile"

--- a/backend-api/src/settings.py
+++ b/backend-api/src/settings.py
@@ -1,11 +1,10 @@
 from functools import lru_cache 
 from pathlib import Path
+import os
+
 
 # Used to validate .env variables
 from pydantic_settings import BaseSettings, SettingsConfigDict 
-
-# Construct absolute path to .env file
-env_file_location = str(Path(__file__).resolve().parent.parent / ".env")
 
 class Settings(BaseSettings):
     SECRET_KEY: str = 'default_secret_key'
@@ -20,7 +19,16 @@ class Settings(BaseSettings):
     QDRANT_URL : str = 'default_qdrant_url'
     QDRANT_COLLECTION_NAME : str = 'default_qdrant_collection_name'
     
-    model_config = SettingsConfigDict(env_file=env_file_location, extra="allow")
+    #guard for production environment
+    model_config = (
+        SettingsConfigDict(
+            env_file=str(Path(__file__).resolve().parent.parent / ".env"),
+            extra="allow",
+        )
+        if os.getenv("ENV") != "production"
+        else SettingsConfigDict(extra="allow")
+    )
+
 
 # Caches the settings instance to avoid re-parsing .env file
 @lru_cache


### PR DESCRIPTION
Cloud Run deployment was failing with: "failed to start and listen on port 8080", but it has been working locally so I assumed it was an environment issue.

Environment class was loading a local .env file which doesn't exist on the cloud run server, causing crash at start up (I think)

I added a guard to .env loading with ENV != "production" and updated the Github Actions pipeline deploy step to set ENV=production