### PR TITLE
New rate-limiter and refactors

### DIFF
--- a/backend-api/src/database.py
+++ b/backend-api/src/database.py
@@ -1,5 +1,4 @@
 import contextlib
-import logging
 from typing import Any, AsyncIterator
 from uuid import uuid4
 
@@ -18,9 +17,8 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 
-from .settings import get_settings
-
-logger = logging.getLogger("uvicorn.error")
+from src.logger import logger
+from src.settings import get_settings
 
 
 # Base class for all ORM models (Helps with Lazy Loading)

--- a/backend-api/src/database.py
+++ b/backend-api/src/database.py
@@ -3,7 +3,6 @@ from typing import Any, AsyncIterator
 from uuid import uuid4
 
 from fastapi import Request
-from redis.asyncio import Redis
 from sqlalchemy.engine.url import make_url
 
 # Building async engine & sessionmaker
@@ -18,7 +17,6 @@ from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 from src.logger import logger
-from src.settings import get_settings
 
 
 # Base class for all ORM models (Helps with Lazy Loading)
@@ -117,19 +115,3 @@ async def get_db_session(request: Request) -> AsyncIterator[AsyncSession]:
     """Dependency that yields a database session"""
     async with request.app.state.session_manager.session() as session:
         yield session
-
-
-# Creates an async Redis Client
-async def init_redis():
-    redis = await Redis(
-        host="redis-13649.crce199.us-west-2-2.ec2.redns.redis-cloud.com",
-        port=13649,
-        decode_responses=True,
-        username="default",
-        password=get_settings().REDIS_PASSWORD,
-        socket_timeout=5,  # Prevents hanging forever
-        socket_connect_timeout=5,
-    )
-    await redis.ping()
-
-    return redis

--- a/backend-api/src/lifespan.py
+++ b/backend-api/src/lifespan.py
@@ -6,13 +6,9 @@ from fastapi import FastAPI
 
 from LLM.core import LLM
 from LLM.Environment import Environment
-
-# Need to import the models in the same module that Base is defined to ensure they are registered with SQLAlchemy
-from src.auth import models  # noqa
 from src.database import DatabaseSessionManager
-from src.llm import models  # noqa
 from src.logger import logger
-from src.settings import get_settings  # Settings management for environment variables
+from src.settings import get_settings
 
 
 @asynccontextmanager

--- a/backend-api/src/lifespan.py
+++ b/backend-api/src/lifespan.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+import traceback
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from LLM.core import LLM
+from LLM.Environment import Environment
+
+# Need to import the models in the same module that Base is defined to ensure they are registered with SQLAlchemy
+from src.auth import models  # noqa
+from src.database import DatabaseSessionManager, init_redis
+from src.llm import models  # noqa
+from src.settings import get_settings  # Settings management for environment variables
+
+logger = logging.getLogger("nautichat")
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Manage async app startup/shutdown events"""
+    logger.info("Starting up application...")
+
+    # Connect to Supabase Postgres as async engine
+    try:
+        async with asyncio.timeout(20):
+            # Setup up database session manager
+            logger.info("Initializing Session Manager...")
+            session_manager = DatabaseSessionManager(get_settings().SUPABASE_DB_URL)
+            app.state.session_manager = session_manager
+            logger.info("Database session manager initialized")
+        async with asyncio.timeout(20):
+            # Initialize Redis client
+            logger.info("Initializing Redis client...")
+            app.state.redis_client = await init_redis()
+            logger.info("Redis client initialized successfully.")
+
+        logger.info("Creating Environment instance...")
+        app.state.env = Environment()
+        logger.info("Environment instance created successfully.")
+
+        logger.info("Initializing LLM (this may take a while)...")
+        try:
+            app.state.llm = LLM(app.state.env)
+            logger.info("LLM instance initialized successfully.")
+        except Exception as e:
+            logger.error(f"LLM initialization failed: {e}")
+            raise RuntimeError(f"LLM initialization failed: {e}")
+
+        logger.info("Getting RAG instance...")
+        app.state.rag = app.state.llm.RAG_instance
+        logger.info("RAG instance initialized successfully.")
+
+    except Exception as e:
+        logger.error(f"Startup failed with error: {str(e)}")
+        logger.error(f"Full traceback: {traceback.format_exc()}")
+        raise RuntimeError(f"Startup failed: {e}")
+
+    logger.info("Running sanity checks...")
+    if not app.state.redis_client:
+        logger.error("Redis client initialization failed")
+        raise RuntimeError("Failed to connect to Redis.")
+    if not app.state.llm:
+        logger.error("LLM initialization failed")
+        raise RuntimeError("Failed to initialize LLM.")
+    if not app.state.rag:
+        logger.error("RAG initialization failed")
+        raise RuntimeError("Failed to initialize RAG.")
+
+    logger.info("App startup complete. All systems go!")
+    yield
+
+    # Teardown
+    logger.info("Shutting down application...")
+    if hasattr(app.state, "session_manager"):
+        await app.state.session_manager.close()
+    if hasattr(app.state, "redis_client"):
+        await app.state.redis_client.aclose()
+    logger.info("Resources cleaned up.")

--- a/backend-api/src/llm/router.py
+++ b/backend-api/src/llm/router.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.auth.dependencies import get_current_user
 from src.auth.schemas import UserOut
 from src.database import get_db_session
+from src.middleware import limiter
 
 from . import service
 from .schemas import (
@@ -50,6 +51,7 @@ async def get_conversation(
 
 
 @router.post("/messages", status_code=201, response_model=Message)
+@limiter.limit("6/minute")
 async def generate_response(
     llm_query: CreateLLMQuery,
     current_user: Annotated[UserOut, Depends(get_current_user)],

--- a/backend-api/src/llm/service.py
+++ b/backend-api/src/llm/service.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 from typing import List
 
 import httpx
@@ -9,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from src.auth.schemas import UserOut
+from src.logger import logger
 
 from .models import Conversation as ConversationModel
 from .models import Feedback as FeedbackModel
@@ -21,9 +21,6 @@ from .schemas import (
     Message,
 )
 from .utils import get_context
-
-logger = logging.getLogger("nautichat")
-
 
 MAX_CONTEXT_WORDS = 200
 

--- a/backend-api/src/logger.py
+++ b/backend-api/src/logger.py
@@ -1,0 +1,15 @@
+import logging
+import sys
+
+# Configure logging to work with uvicorn
+logger = logging.getLogger("nautichat")
+logger.setLevel(logging.DEBUG)
+
+# Create console handler if it doesn't exist
+if not logger.handlers:
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s - %(message)s")
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+    logger.propagate = False  # Prevent double logging in uvicorn

--- a/backend-api/src/main.py
+++ b/backend-api/src/main.py
@@ -1,100 +1,13 @@
-import asyncio
-import logging
-import sys
-import traceback
-from contextlib import asynccontextmanager
-
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 
-from LLM.core import LLM
-from LLM.Environment import Environment
 from src.admin.router import router as admin_router
-
-# Need to import the models in the same module that Base is defined to ensure they are registered with SQLAlchemy
-from src.auth import models  # noqa
 from src.auth.router import router as auth_router
-from src.database import DatabaseSessionManager, init_redis
-from src.llm import models  # noqa
+from src.lifespan import lifespan
 from src.llm.router import router as llm_router
-from src.settings import get_settings  # Settings management for environment variables
-
-# Configure logging to work with uvicorn
-logger = logging.getLogger("nautichat")
-logger.setLevel(logging.DEBUG)
-
-# Create console handler if it doesn't exist
-if not logger.handlers:
-    console_handler = logging.StreamHandler(sys.stdout)
-    console_handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(name)s - %(message)s")
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+from src.logger import logger
+from src.middleware import init_middleware
 
 logger.info("NAUTICHAT BACKEND STARTING")
-
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    """Manage async app startup/shutdown events"""
-    logger.info("Starting up application...")
-
-    # Connect to Supabase Postgres as async engine
-    try:
-        async with asyncio.timeout(20):
-            # Setup up database session manager
-            logger.info("Initializing Session Manager...")
-            session_manager = DatabaseSessionManager(get_settings().SUPABASE_DB_URL)
-            app.state.session_manager = session_manager
-            logger.info("Database session manager initialized")
-        async with asyncio.timeout(20):
-            # Initialize Redis client
-            logger.info("Initializing Redis client...")
-            app.state.redis_client = await init_redis()
-            logger.info("Redis client initialized successfully.")
-
-        logger.info("Creating Environment instance...")
-        app.state.env = Environment()
-        logger.info("Environment instance created successfully.")
-
-        logger.info("Initializing LLM (this may take a while)...")
-        try:
-            app.state.llm = LLM(app.state.env)
-            logger.info("LLM instance initialized successfully.")
-        except Exception as e:
-            logger.error(f"LLM initialization failed: {e}")
-            raise RuntimeError(f"LLM initialization failed: {e}")
-
-        logger.info("Getting RAG instance...")
-        app.state.rag = app.state.llm.RAG_instance
-        logger.info("RAG instance initialized successfully.")
-
-    except Exception as e:
-        logger.error(f"Startup failed with error: {str(e)}")
-        logger.error(f"Full traceback: {traceback.format_exc()}")
-        raise RuntimeError(f"Startup failed: {e}")
-
-    logger.info("Running sanity checks...")
-    if not app.state.redis_client:
-        logger.error("Redis client initialization failed")
-        raise RuntimeError("Failed to connect to Redis.")
-    if not app.state.llm:
-        logger.error("LLM initialization failed")
-        raise RuntimeError("Failed to initialize LLM.")
-    if not app.state.rag:
-        logger.error("RAG initialization failed")
-        raise RuntimeError("Failed to initialize RAG.")
-
-    logger.info("App startup complete. All systems go!")
-    yield
-
-    # Teardown
-    logger.info("Shutting down application...")
-    if hasattr(app.state, "session_manager"):
-        await app.state.session_manager.close()
-    if hasattr(app.state, "redis_client"):
-        await app.state.redis_client.aclose()
-    logger.info("Resources cleaned up.")
 
 
 def create_app():
@@ -106,22 +19,11 @@ def create_app():
         lifespan=lifespan,
     )
 
-    origins = ["http://localhost:3000", "https://nautichat.vercel.app"]
-
-    # Add CORS middleware  to enable frontend-backend communications
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
-    logger.info("CORS middleware added.")
+    init_middleware(app)
 
     # Add a root endpoint for testing
     @app.get("/")
     async def root():
-        logger.info("Root endpoint accessed")
         return {
             "message": "NautiChat Backend API is running!",
             "docs": "/docs",
@@ -132,7 +34,6 @@ def create_app():
     @app.get("/health")
     async def health_check():
         """Health check endpoint"""
-        logger.info("Health check endpoint accessed")
         return {
             "status": "healthy",
             "database": "connected",

--- a/backend-api/src/middleware.py
+++ b/backend-api/src/middleware.py
@@ -1,62 +1,72 @@
-from typing import Optional
-
 import anyio
-from fastapi import Request, status
+from fastapi import Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from redis.asyncio import Redis  # Async Redis Client
-from starlette.middleware.base import (
-    BaseHTTPMiddleware,
-)  # Base class for custom middleware
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from src.logger import logger
+from src.settings import get_settings
+
+TIMEOUT_SECONDS = 30
 
 
-# TODO: There should be try/except for catching Redis Errors (If Redis is unavailable)
-class RateLimitMiddleware(BaseHTTPMiddleware):
-    def __init__(self, app, window_sec: int = 30, max_requests: int = 30):
+class TimeoutMiddleware(BaseHTTPMiddleware):
+    """
+    Middleware to handle request timeouts.
+    If a request takes longer than the specified timeout, it returns a 504 Gateway Timeout response.
+    """
+
+    def __init__(self, app):
         super().__init__(app)
-        self.window_sec = window_sec  # Time window in seconds
-        self.max_requests = max_requests  # Max allowed requests in time window
-
-    async def permit_request(self, redis: Redis, key: str):
-        # If the ip does not exist in the cache, add it with the value of max_requests
-        # and set the expiration time to window_sec
-        await redis.set(key, self.max_requests, ex=self.window_sec, nx=True)
-        cache_val: Optional[bytes] = await redis.get(key)
-
-        if cache_val is not None:
-            requests_remaining = int(cache_val)
-            if requests_remaining > 0:
-                await redis.decr(key)
-                return True
-
-        return False  # Rate limit got exceeded
+        self.timeout_seconds = TIMEOUT_SECONDS
 
     async def dispatch(self, request: Request, call_next):
-        if not request.client:
-            raise ValueError("Client IP not found")
+        response = None
+        with anyio.move_on_after(self.timeout_seconds) as scope:
+            response = await call_next(request)
 
-        # Track per-user requests
-        client_ip = request.client.host
-        redis: Redis = request.app.state.redis_client
-        key = f"{client_ip}:RATELIMIT"
-
-        # If Rate limit got exceeded
-        if not await self.permit_request(redis, key):
-            time_to_wait = await redis.ttl(key)
-            retry_info = (
-                f" Retry after {int(time_to_wait)}" if time_to_wait is not None else ""
-            )
-            return JSONResponse(
-                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-                content={"detail": f"Rate limit exceeded.{retry_info}"},
-            )
-        try:
-            with anyio.move_on_after(30) as scope:
-                response = await call_next(request)
-                if scope.cancel_called:
-                    raise TimeoutError("Request exceeded 30s")
-        except TimeoutError:
+        if scope.cancel_called or response is None:
             return JSONResponse(
                 status_code=504,
                 content={"detail": "Request timed out"},
             )
+
         return response
+
+
+# Gloabal limiter class
+limiter = Limiter(
+    key_func=get_remote_address,
+    storage_uri=f"redis://default:{get_settings().REDIS_PASSWORD}@redis-13649.crce199.us-west-2-2.ec2.redns.redis-cloud.com:13649",
+    default_limits=["80/minute"],
+)
+
+
+def init_middleware(app):
+    """
+    Initializes the middleware for the FastAPI application.
+    This function is called during application startup.
+    """
+
+    origins = ["http://localhost:3000", "https://nautichat.vercel.app"]
+
+    # Add CORS middleware  to enable frontend-backend communications
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    logger.info("CORS middleware added.")
+
+    # Add slowapi rate limiter
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore
+
+    app.add_middleware(TimeoutMiddleware)
+
+    logger.info("Middleware initialized successfully.")

--- a/backend-api/src/middleware.py
+++ b/backend-api/src/middleware.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -66,6 +67,7 @@ def init_middleware(app):
     # Add slowapi rate limiter
     app.state.limiter = limiter
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore
+    app.add_middleware(SlowAPIMiddleware)
 
     app.add_middleware(TimeoutMiddleware)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -119,6 +119,7 @@ sentence-transformers==4.1.0
 setuptools==80.9.0
 shellingham==1.5.4
 six==1.17.0
+slowapi
 sniffio==1.3.1
 SQLAlchemy==2.0.41
 stack-data==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,7 +106,6 @@ pywin32==310 ; sys_platform == "win32"
 PyYAML==6.0.2
 pyzmq==26.4.0
 qdrant-client==1.14.2
-redis==6.2.0
 regex==2024.11.6
 requests==2.32.3
 requests-toolbelt==1.0.0


### PR DESCRIPTION
- add new rate limiter using slowapi library. redis is still used for storage but is managed by slowapi instead of a custom middleware.
- add new TimeoutMiddleware which handles the timeout logic that was being handled by old custom rate limiter.
- move out the lifespan object from main.py into lifespan.py.
- create init_middleware function instead of doing so in main.py.
- move out logging set-up from main.py into logging.py.

The old rate limiter was sometimes running into an issue where a value in the cache would exist without an expiry time, making the IP rate limited forever. The frontend was also running into rate limits, even with a very relaxed limit. This would have caused problems for the endpoints we actually want limited such as POST messages. Instead of refactoring the custom rate limiter to support different rates for endpoints, it was much easier to move to slowapi.