### PR TITLE
Add lint check to pipeline

### DIFF
--- a/.github/workflows/ci_cd_pipeline.yml
+++ b/.github/workflows/ci_cd_pipeline.yml
@@ -1,139 +1,159 @@
 name: CI/CD Pipeline
 
 on:
-  push:
-    branches: [ main, fix-deployment ]
-  pull_request:
+    push:
+        branches: [main]
+    pull_request:
 
 permissions:
-  contents: read
-  id-token: write
+    contents: read
+    id-token: write
 
 env:
-  REGION: northamerica-northeast1 #torono
-  ARTIFACT_REPO: nautichat
-  IMAGE_NAME: >-
-    ${{ vars.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.ARTIFACT_REPO }}/nautichat
+    REGION: northamerica-northeast1 #torono
+    ARTIFACT_REPO: nautichat
+    IMAGE_NAME: >-
+        ${{ vars.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ vars.ARTIFACT_REPO }}/nautichat
 
 jobs:
-  # Tests
-  test:
-    runs-on: ubuntu-latest
+    lint:
+        name: Lint (pre-commit)
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-    env:
-      SUPABASE_DB_URL: "${{ secrets.SUPABASE_DB_URL }}"
-      SECRET_KEY: ci_dummy_key
-      ALGORITHM: HS256
-      ACCESS_TOKEN_EXPIRE_HOURS: "24"
-      REDIS_PASSWORD : ${{ secrets.REDIS_PASSWORD }}
-      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }} 
-      ONC_TOKEN: ${{ secrets.ONC_TOKEN }}
+            - name: Set up Python
+              uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
 
-    steps:
-      - uses: actions/checkout@v4
+            - name: Install dependencies
+              run: |
+                  pip install --upgrade pip
+                  pip install pre-commit
+                  pre-commit install
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
+            - name: Run pre-commit on all files
+              run: pre-commit run --all-files
+    test:
+        runs-on: ubuntu-latest
 
-      - name: Install deps
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest
-          pip install pytest-asyncio
-
-      - name: Run pytest
-        run: python -m pytest -q
-  build-pr:  # (just checks Docker build locally)
-    if: github.event_name == 'pull_request'  && github.head_ref != 'fix-deployment' #Ensure fix-deployment goes through build->deploy
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to:   type=gha,mode=max #    ^
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          tags: |
-            ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
-
-  # Build + Push
-  build:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix-deployment')
-    runs-on: ubuntu-latest
-    needs: test
-
-    steps:
-      - uses: actions/checkout@v4
-      
-      # Google Cloud (Workload Identity)
-      - id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCLOUD_SERVICE_KEY }}
-          token_format: 'access_token'
-          access_token_scopes: 'https://www.googleapis.com/auth/cloud-platform'
-
-      # Docker login to Artifact Registry
-      - uses: docker/login-action@v3
-        with:
-          username: 'oauth2accesstoken'
-          password: ${{ steps.auth.outputs.access_token }}
-          registry: '${{ env.REGION }}-docker.pkg.dev'
-
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/build-push-action@v5
-        with:
-          context: .
-          platforms: linux/amd64
-          push: true
-          cache-from: type=gha
-          cache-to:   type=gha,mode=max
-          tags: |
-            ${{ env.IMAGE_NAME }}:latest
-            ${{ env.IMAGE_NAME }}:${{ github.sha }}
-
-  # Deploy
-  deploy:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fix-deployment')
-    runs-on: ubuntu-latest
-    needs: build
-    environment: production
-
-    steps:
-      - id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCLOUD_SERVICE_KEY }}
-          token_format: 'access_token'
-          access_token_scopes: 'https://www.googleapis.com/auth/cloud-platform'
-
-      - id: deploy
-        uses: google-github-actions/deploy-cloudrun@v2
-        with:
-          service:  ${{ secrets.SERVICE_NAME }}
-          region:   ${{ env.REGION }}
-          image:    ${{ env.IMAGE_NAME }}:${{ github.sha }}
-          flags: |
-            --allow-unauthenticated
-          env_vars: |
-            ENV=production
+        env:
             SUPABASE_DB_URL: "${{ secrets.SUPABASE_DB_URL }}"
-            SECRET_KEY=${{ vars.SECRET_KEY }}
-            ALGORITHM=${{ vars.ALGORITHM }}
-            ACCESS_TOKEN_EXPIRE_HOURS=${{ vars.ACCESS_TOKEN_EXPIRE_HOURS }}
-            REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
-            GROQ_API_KEY=${{ secrets.GROQ_API_KEY }}
-            QDRANT_URL=${{ secrets.QDRANT_URL }}
-            QDRANT_API_KEY=${{ secrets.QDRANT_API_KEY }}
-            QDRANT_COLLECTION_NAME=${{ secrets.QDRANT_COLLECTION_NAME }}
-            CAMBRIDGE_LOCATION_CODE=${{ secrets.CAMBRIDGE_LOCATION_CODE }}
-            ONC_TOKEN=${{ secrets.ONC_TOKEN }}
+            SECRET_KEY: ci_dummy_key
+            ALGORITHM: HS256
+            ACCESS_TOKEN_EXPIRE_HOURS: "24"
+            REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+            GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+            ONC_TOKEN: ${{ secrets.ONC_TOKEN }}
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-python@v5
+              with:
+                  python-version: "3.12"
+                  cache: "pip"
+
+            - name: Install deps
+              run: |
+                  python -m pip install --upgrade pip
+                  if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+                  pip install pytest
+                  pip install pytest-asyncio
+
+            - name: Run pytest
+              run: python -m pytest -q
+    build-pr: # (just checks Docker build locally)
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        needs: [test, lint]
+        steps:
+            - uses: actions/checkout@v4
+            - uses: docker/setup-buildx-action@v3
+            - uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  platforms: linux/amd64
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+                  push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+                  tags: |
+                      ${{ env.IMAGE_NAME }}:latest
+                      ${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+    # Build + Push
+    build:
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        runs-on: ubuntu-latest
+        needs: test
+
+        steps:
+            - uses: actions/checkout@v4
+
+            # Google Cloud (Workload Identity)
+            - id: auth
+              uses: google-github-actions/auth@v2
+              with:
+                  credentials_json: ${{ secrets.GCLOUD_SERVICE_KEY }}
+                  token_format: "access_token"
+                  access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
+
+            # Docker login to Artifact Registry
+            - uses: docker/login-action@v3
+              with:
+                  username: "oauth2accesstoken"
+                  password: ${{ steps.auth.outputs.access_token }}
+                  registry: "${{ env.REGION }}-docker.pkg.dev"
+
+            - uses: docker/setup-buildx-action@v3
+
+            - uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  platforms: linux/amd64
+                  push: true
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+                  tags: |
+                      ${{ env.IMAGE_NAME }}:latest
+                      ${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+    # Deploy
+    deploy:
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        runs-on: ubuntu-latest
+        needs: build
+        environment: production
+
+        steps:
+            - id: auth
+              uses: google-github-actions/auth@v2
+              with:
+                  credentials_json: ${{ secrets.GCLOUD_SERVICE_KEY }}
+                  token_format: "access_token"
+                  access_token_scopes: "https://www.googleapis.com/auth/cloud-platform"
+
+            - id: deploy
+              uses: google-github-actions/deploy-cloudrun@v2
+              with:
+                  service: ${{ secrets.SERVICE_NAME }}
+                  region: ${{ env.REGION }}
+                  image: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+                  flags: |
+                      --allow-unauthenticated
+                  env_vars: |
+                      ENV=production
+                      SUPABASE_DB_URL: "${{ secrets.SUPABASE_DB_URL }}"
+                      SECRET_KEY=${{ vars.SECRET_KEY }}
+                      ALGORITHM=${{ vars.ALGORITHM }}
+                      ACCESS_TOKEN_EXPIRE_HOURS=${{ vars.ACCESS_TOKEN_EXPIRE_HOURS }}
+                      REDIS_PASSWORD=${{ secrets.REDIS_PASSWORD }}
+                      GROQ_API_KEY=${{ secrets.GROQ_API_KEY }}
+                      QDRANT_URL=${{ secrets.QDRANT_URL }}
+                      QDRANT_API_KEY=${{ secrets.QDRANT_API_KEY }}
+                      QDRANT_COLLECTION_NAME=${{ secrets.QDRANT_COLLECTION_NAME }}
+                      CAMBRIDGE_LOCATION_CODE=${{ secrets.CAMBRIDGE_LOCATION_CODE }}
+                      ONC_TOKEN=${{ secrets.ONC_TOKEN }}

--- a/LLM/Constants/statusCodes.py
+++ b/LLM/Constants/statusCodes.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class StatusCode(Enum):
     REGULAR_MESSAGE = 1
     PROCESSING_DATA_DOWNLOAD = 2

--- a/LLM/schemas.py
+++ b/LLM/schemas.py
@@ -1,24 +1,32 @@
-from typing import Optional #,List
+from typing import Optional
 
 from pydantic import BaseModel
+
 from LLM.Constants.StatusCodes import StatusCode
+
 
 class ObtainedParamsDictionary(BaseModel):
     """Parameters obtained from the user"""
+
     deviceCategoryCode: Optional[str] = None
     locationCode: Optional[str] = None
     dataProductCode: Optional[str] = None
     extension: Optional[str] = None
     dateFrom: Optional[str] = None
     dateTo: Optional[str] = None
-    dpo_qualityControl: Optional[int] = 0 #default is 0, which means no quality control
-    dpo_resample: Optional[str] = "none" #default is "none", which means no resampling
-    dpo_dataGaps: Optional[int] = 1 #default is 1, which means data gaps are included
+
+    dpo_qualityControl: Optional[int] = 0  # default is 0, which means no qc
+    dpo_resample: Optional[str] = "none"  # default is "none", which means no resampling
+    dpo_dataGaps: Optional[int] = 1  # default is 1, which means data gaps are included
+
+
 class RunConversationResponse(BaseModel):
     """Response from running a conversation with the LLM"""
+
     status: StatusCode
     response: str
     obtainedParams: Optional[ObtainedParamsDictionary] = None
     dpRequestId: Optional[int] = None
-    doi: Optional[str] = None  #may need to switch to a list of strings if we go through citations and make a list of all of them
-    citation: Optional[str] = None  #may need to switch to a list of strings
+    # may need to switch to a list of strings if we go through citations and make a list of all of them
+    doi: Optional[str] = None
+    citation: Optional[str] = None  # may need to switch to a list of strings

--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ uvicorn src.main:app --reload
 
 # 5. (Alternative) Run with Docker Compose
 docker compose up --build
+```
+
+## Pre-commit
+
+The project uses pre-commit to run actions before a commit. To get pre-commit set up locally to run before a commit run `pre-commit install`. The pre-commit hook can also be run manually with `pre-commit run --all-files`.

--- a/backend-api/README.md
+++ b/backend-api/README.md
@@ -1,20 +1,10 @@
-# NautiChat-Backend
+# NautiChat-Backend API
 
-The backend provides endpoints to
+The api provides endpoints to
 
 - Generate responses with the LLM
 - Authenticate / register users
 - View previous responses from the LLM
 - Provide feedback for an LLM response
 
-The endpoints lead to a local SQLite database setup.
-Prior to running any endpoints, ensure that a folder called "db" exists:
-- backend-api\db\\*Some_Database_Name.db*
-
 The backend also handles rate limiting
-
-Install dependencies `pip install -r requirements.txt`  
-Update dependencies `pip freeze > requirements.txt`  
-
-Run with `fastapi dev main.py`  
-Docs at `{server}/docs`  


### PR DESCRIPTION
pre-commit requires the command `pre-commit install` to be run before any hooks are run automatically. there was no lint step in the pipeline so it was easy to forget that command and commit un-formatted code. the pre-commit hook is now added to the pipeline as a lint step which will fail if any code is unformatted, so that going forward all the code in the repo should be formatted.