### PR TITLE
add endpoint for guest login

### DIFF
--- a/backend-api/src/auth/router.py
+++ b/backend-api/src/auth/router.py
@@ -28,6 +28,15 @@ async def login(
     return await service.login_user(form_data, settings, db)
 
 
+@router.post("/guest-login", response_model=Token)
+async def guest_login(
+    settings: Annotated[Settings, Depends(get_settings)],
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> Token:
+    """Authenticate guest user"""
+    return await service.guest_login(settings, db)
+
+
 @router.post("/register", status_code=201, response_model=Token)
 async def register_user(
     user_request: CreateUserRequest,

--- a/backend-api/src/auth/service.py
+++ b/backend-api/src/auth/service.py
@@ -1,3 +1,5 @@
+import random
+import string
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -136,6 +138,21 @@ async def login_user(
         settings,
     )
     return Token(access_token=token, token_type="bearer")
+
+
+# Create an actual user entry in db for each guest. No current method for deleting guests.
+async def guest_login(settings: Settings, db: AsyncSession) -> Token:
+    """Authenticate guest user"""
+    chars = string.ascii_letters + string.digits
+
+    guest_username = "guest_" + "".join(random.choice(chars) for _ in range(8))
+    guest_password = "".join(random.choice(chars) for _ in range(12))
+    onc_token = settings.ONC_TOKEN  # use global ONC token for guests
+
+    create_user_request = CreateUserRequest(
+        username=guest_username, password=guest_password, onc_token=onc_token
+    )
+    return await register_user(create_user_request, settings, db)
 
 
 async def update_onc_token(

--- a/backend-api/test/test_auth.py
+++ b/backend-api/test/test_auth.py
@@ -108,6 +108,20 @@ async def test_login_existing_user(client: AsyncClient, async_session: AsyncSess
 
 
 @pytest.mark.asyncio
+async def test_login_guest_user(client: AsyncClient, async_session: AsyncSession):
+    response = await client.post("/auth/guest-login")
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["token_type"] == "bearer"
+    assert isinstance(data["access_token"], str)
+
+    # make sure a guest user was created in the db
+    query = await async_session.execute(select(models.User))
+    users = query.scalars().all()
+    assert len(users) == 1
+
+
+@pytest.mark.asyncio
 async def test_login_invalid_user(client: AsyncClient):
     # add user. since adding directly to db the password is not hashed which is easier for testing
 


### PR DESCRIPTION
instead of frontend having to store anything locally for a guest, an endpoint is provided to get a jwt for a new guest user.

in the backend, a normal user is created. there is currently no cleanup in the database to delete guest user data after some amount of time. if we have time, this could be added. the settings class is currently setting default values for ONC_TOKEN which is not good, but this should be addressed in a different pr.