### PR TITLE
add ONC token validation

### DIFF
--- a/backend-api/src/auth/router.py
+++ b/backend-api/src/auth/router.py
@@ -81,13 +81,3 @@ async def change_password(
 ) -> UserOut:
     """Change the password for the user"""
     return await service.change_user_password(request, user, db)
-
-
-@router.put("/me/onc-token", response_model=UserOut)
-async def update_onc_token(
-    user: Annotated[User, Depends(get_current_user)],
-    onc_token: str,
-    db: Annotated[AsyncSession, Depends(get_db_session)],
-) -> UserOut:
-    """Update the ONC token for the current user"""
-    return await service.update_onc_token(user, onc_token, db)

--- a/backend-api/src/auth/service.py
+++ b/backend-api/src/auth/service.py
@@ -41,14 +41,13 @@ async def validate_onc_token(token: str):
     # call the ONC api to verify the token
     # call an endpoint with missing parameters so that it returns quickly in both valid and invalid token cases
 
-    async with AsyncClient() as client:
+    async with AsyncClient(timeout=5) as client:
         response = await client.get(
             f"https://data.oceannetworks.ca/api/locations?locationCode=INVALID&token={token}"
         )
         data = response.json()
-        print(data)
-        assert "errors" in data, "ONC changed the API, update the validation logic"
-        print("validating token:", token)
+        if "errors" not in data:
+            raise RuntimeError("ONC changed the API, update the validation logic")
         for error in data["errors"]:
             if error["parameter"] == "token":
                 raise HTTPException(

--- a/backend-api/src/auth/service.py
+++ b/backend-api/src/auth/service.py
@@ -6,6 +6,7 @@ from typing import Optional
 import jwt  # JSON Web Token for creating and decoding tokens
 from fastapi import HTTPException, status
 from fastapi.security import OAuth2PasswordRequestForm
+from httpx import AsyncClient
 from jwt.exceptions import InvalidTokenError
 from passlib.context import CryptContext  # For password hashing and verification
 from sqlalchemy import select
@@ -34,6 +35,28 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 
+async def validate_onc_token(token: str):
+    """Verify the ONC token by making a request to the ONC API"""
+
+    # call the ONC api to verify the token
+    # call an endpoint with missing parameters so that it returns quickly in both valid and invalid token cases
+
+    async with AsyncClient() as client:
+        response = await client.get(
+            f"https://data.oceannetworks.ca/api/locations?locationCode=INVALID&token={token}"
+        )
+        data = response.json()
+        print(data)
+        assert "errors" in data, "ONC changed the API, update the validation logic"
+        print("validating token:", token)
+        for error in data["errors"]:
+            if error["parameter"] == "token":
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Invalid ONC token",
+                )
+
+
 def create_access_token(
     username: str,
     expires_delta: timedelta,
@@ -56,6 +79,8 @@ async def create_new_user(
     user_data: CreateUserRequest, db: AsyncSession, is_admin: bool = False
 ) -> UserModel:
     """Create a new user and add to db"""
+
+    await validate_onc_token(user_data.onc_token)
 
     # Check if existing user with same username exists in db
     existing_user = await get_user(user_data.username, db)
@@ -154,6 +179,7 @@ async def update_user_info(
         updated = True
 
     if updated_user.onc_token:
+        await validate_onc_token(updated_user.onc_token)
         user.onc_token = updated_user.onc_token
         updated = True
 
@@ -243,17 +269,3 @@ async def guest_login(settings: Settings, db: AsyncSession) -> Token:
         username=guest_username, password=guest_password, onc_token=onc_token
     )
     return await register_user(create_user_request, settings, db)
-
-
-async def update_onc_token(
-    user: UserModel, new_onc_token: str, db: AsyncSession
-) -> UserModel:
-    """Update the ONC token for the given user"""
-
-    user.onc_token = new_onc_token
-
-    # Update DB
-    await db.commit()
-    await db.refresh(user)
-
-    return user

--- a/backend-api/test/conftest.py
+++ b/backend-api/test/conftest.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
+from src.settings import get_settings
 
 # Set up test DB URL
 # TODO: Create a Postgres Test DB for thorough testing
@@ -19,7 +20,6 @@ from src.auth import models
 from src.auth.service import create_access_token, get_password_hash
 from src.database import Base, get_db_session
 from src.main import create_app
-from src.settings import get_settings
 
 
 @pytest.fixture
@@ -78,7 +78,7 @@ async def user_headers(async_session: AsyncSession):
     test_user = models.User(
         username="testuser",
         hashed_password=get_password_hash("hashedpassword"),
-        onc_token="onctoken",
+        onc_token=get_settings().ONC_TOKEN,
         is_admin=False,
     )
 
@@ -103,7 +103,7 @@ async def admin_headers(async_session: AsyncSession):
     admin_user = models.User(
         username="admin",
         hashed_password="nothashedpassword",
-        onc_token="admintoken",
+        onc_token=get_settings().ONC_TOKEN,
         is_admin=True,
     )
 

--- a/backend-api/test/test_admin.py
+++ b/backend-api/test/test_admin.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi import status
 from httpx import AsyncClient
+from src.settings import get_settings
 
 
 @pytest.mark.asyncio
@@ -20,7 +21,7 @@ async def test_create_admin_success(client: AsyncClient, admin_headers):
     new_admin_data = {
         "username": "newadmin",
         "password": "securepass123",
-        "onc_token": "token123",
+        "onc_token": get_settings().ONC_TOKEN,
     }
 
     response = await client.post(
@@ -37,7 +38,11 @@ async def test_create_admin_success(client: AsyncClient, admin_headers):
 async def test_create_admin_unauthenticated(client: AsyncClient):
     response = await client.post(
         "/admin/create",
-        json={"username": "unauth", "password": "x", "onc_token": "y"},
+        json={
+            "username": "unauth",
+            "password": "x",
+            "onc_token": get_settings().ONC_TOKEN,
+        },
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -46,7 +51,11 @@ async def test_create_admin_unauthenticated(client: AsyncClient):
 async def test_create_admin_as_normal_user(client: AsyncClient, user_headers):
     response = await client.post(
         "/admin/create",
-        json={"username": "baduser", "password": "x", "onc_token": "y"},
+        json={
+            "username": "baduser",
+            "password": "x",
+            "onc_token": get_settings().ONC_TOKEN,
+        },
         headers=user_headers,
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/backend-api/test/test_auth.py
+++ b/backend-api/test/test_auth.py
@@ -5,12 +5,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from src.auth import models, schemas
 from src.auth.service import get_password_hash
+from src.settings import get_settings
 
 
 @pytest.mark.asyncio
 async def test_register_new_user(client: AsyncClient, async_session: AsyncSession):
     new_user = schemas.CreateUserRequest(
-        username="lebron", password="cavs", onc_token="lebrontoken"
+        username="lebron", password="cavs", onc_token=get_settings().ONC_TOKEN
     )
     response = await client.post("/auth/register", json=new_user.model_dump())
 
@@ -36,8 +37,9 @@ async def test_register_new_user(client: AsyncClient, async_session: AsyncSessio
 @pytest.mark.asyncio
 async def test_register_existing_user(client: AsyncClient, async_session: AsyncSession):
     # add a user
+    valid_onc_token = get_settings().ONC_TOKEN
     existing_user = models.User(
-        username="lebron", hashed_password="cavs", onc_token="lebrontoken"
+        username="lebron", hashed_password="cavs", onc_token=valid_onc_token
     )
 
     async_session.add(existing_user)
@@ -47,7 +49,7 @@ async def test_register_existing_user(client: AsyncClient, async_session: AsyncS
     user_attempt = schemas.CreateUserRequest(
         username=existing_user.username,
         password="differentpassword",
-        onc_token="differenttoken",
+        onc_token=valid_onc_token,
     )
     response = await client.post("/auth/register", json=user_attempt.model_dump())
     assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -55,6 +57,25 @@ async def test_register_existing_user(client: AsyncClient, async_session: AsyncS
     query = await async_session.execute(select(models.User))
     users = query.scalars().all()
     assert len(users) == 1, "duplicate user was added"
+
+
+@pytest.mark.asyncio
+async def test_register_invalid_onc_token(
+    client: AsyncClient, async_session: AsyncSession
+):
+    new_user = schemas.CreateUserRequest(
+        username="lebron", password="cavs", onc_token="invalid_token"
+    )
+    response = await client.post("/auth/register", json=new_user.model_dump())
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    data = response.json()
+    assert data["detail"] == "Invalid ONC token"
+
+    # make sure no user was added to the db
+    query = await async_session.execute(select(models.User))
+    users = query.scalars().all()
+    assert len(users) == 0, "user was added with invalid ONC token"
 
 
 @pytest.mark.asyncio
@@ -88,7 +109,7 @@ async def test_login_existing_user(client: AsyncClient, async_session: AsyncSess
     user = models.User(
         username="new user",
         hashed_password=get_password_hash(password),
-        onc_token="newtoken",
+        onc_token=get_settings().ONC_TOKEN,
     )
 
     async_session.add(user)
@@ -138,21 +159,45 @@ async def test_login_invalid_user(client: AsyncClient):
 async def test_update_user_info_success(
     client: AsyncClient, async_session: AsyncSession, user_headers
 ):
-    new_info = {"username": "updated_user", "onc_token": "new_onc_token"}
+    valid_onc_token = get_settings().ONC_TOKEN
+    new_info = {"username": "updated_user", "onc_token": valid_onc_token}
 
     response = await client.put("/auth/me", json=new_info, headers=user_headers)
     assert response.status_code == status.HTTP_200_OK
 
     updated = response.json()
     assert updated["username"] == "updated_user"
-    assert updated["onc_token"] == "new_onc_token"
+    assert updated["onc_token"] == valid_onc_token
 
     result = await async_session.execute(
         select(models.User).where(models.User.username == "updated_user")
     )
     user = result.scalar_one_or_none()
     assert user is not None
-    assert user.onc_token == "new_onc_token"
+    assert user.onc_token == valid_onc_token
+
+
+@pytest.mark.asyncio
+async def test_update_invalid_onc_token(
+    client: AsyncClient, async_session: AsyncSession, user_headers
+):
+    # get current user in db
+    query = await async_session.execute(select(models.User))
+    current_user = query.scalar_one_or_none()
+    assert current_user is not None
+    user_valid_onc_token = current_user.onc_token
+
+    new_info = {"username": "updated_user", "onc_token": "invalid_token"}
+
+    response = await client.put("/auth/me", json=new_info, headers=user_headers)
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Invalid ONC token"
+
+    # make sure user onc token is still valid
+    query = await async_session.execute(select(models.User))
+    current_user = query.scalar_one_or_none()
+    assert current_user is not None
+    assert current_user.onc_token == user_valid_onc_token
 
 
 @pytest.mark.asyncio
@@ -162,7 +207,7 @@ async def test_update_user_info_username_exists(
     other_user = models.User(
         username="existing_user",
         hashed_password=get_password_hash("irrelevant"),
-        onc_token="existing_token",
+        onc_token=get_settings().ONC_TOKEN,
     )
 
     async_session.add(other_user)

--- a/backend-api/test/test_llm.py
+++ b/backend-api/test/test_llm.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.auth.models import User
 from src.llm.models import Conversation, Message
 from src.llm.utils import get_context
+from src.settings import get_settings
 
 
 class DummyLLM:
@@ -96,7 +97,8 @@ async def test_get_conversation_unauthorized(client: AsyncClient, user_headers):
     ).json()["conversation_id"]
 
     reg = await client.post(
-        "/auth/register", json={"username": "x", "password": "p", "onc_token": "tok"}
+        "/auth/register",
+        json={"username": "x", "password": "p", "onc_token": get_settings().ONC_TOKEN},
     )
     headers2 = {"Authorization": f"Bearer {reg.json()['access_token']}"}
 
@@ -130,7 +132,11 @@ async def test_delete_conversation_unauthorized(client: AsyncClient, user_header
 
     reg = await client.post(
         "/auth/register",
-        json={"username": "someoneelse", "password": "1234", "onc_token": "abc"},
+        json={
+            "username": "someoneelse",
+            "password": "1234",
+            "onc_token": get_settings().ONC_TOKEN,
+        },
     )
 
     other_token = reg.json()["access_token"]


### PR DESCRIPTION
add a service function which validates an ONC token, and raises and HTTPException if its invalid. api routes call this function to make sure that any token passed in is valid.

since we have two different env files right now, we have to add the ONC_TOKEN to the backend env file so tests will pass locally. hopefully the two env files are combined soon.