### PR TITLE
Sprint 2 dd queries

### DIFF
--- a/LLM/Constants/tool_descriptions.py
+++ b/LLM/Constants/tool_descriptions.py
@@ -414,27 +414,57 @@ toolDescriptions = [
             },
         },
     },
-    # {
-    #     "type": "function",
-    #     "function": {
-    #         "name": "get_ship_noise_for_date",
-    #         "description": "Get 24 hours of ship-noise data for Cambridge Bay on a specific date, returned as a JSON string of the full time series.",
-    #         "parameters": {
-    #             "type": "object",
-    #             "properties": {
-    #                 "date_from_str": {
-    #                     "type": "string",
-    #                     "description": "Date in YYYY-MM-DD format (e.g. \"2024-07-31\") for which to retrieve ship-noise data."
-    #                 },
-    #                 "user_onc_token": {
-    #                     "type": "string",
-    #                     "description": "User's ONC token for API access. This is required to access the data.",
-    #                 }
-    #             },
-    #             "required": ["date_from_str", "user_onc_token"]
-    #         },
-    #     },
-    # },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_ship_noise_acoustic_for_date",
+            "description": (
+            "Get 24 hours of ship noise acoustic data for Cambridge Bay using the ONC hydrophone system. "
+            "This function requests a downloadable WAV audio data product from the Ocean Networks Canada API, "
+            "using device category 'HYDROPHONE' at location 'CBYIP'. It returns order metadata including a URL, "
+            "parameters used in the request, and a description of the data order."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "date_from_str": {
+                        "type": "string",
+                        "description": "Date in YYYY-MM-DD format representing the start of the 24-hour window."
+                    },
+                    "user_onc_token": {
+                        "type": "string",
+                        "description": "User's ONC API access token."
+                    }
+                },
+                "required": ["date_from_str", "user_onc_token"]
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "plot_spectrogram_for_date",
+            "description": (
+            "Retrieve a pre-generated spectrogram image for hydrophone data from Cambridge Bay. "
+            "This function downloads a PNG spectrogram (data product code 'HSD') from the Ocean Networks Canada API "
+            "for a 24-hour period starting from the given date. It returns the image as a PIL.Image.Image object if successful."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "date_str": {
+                        "type": "string",
+                        "description": "Date in YYYY-MM-DD format representing the start of the 24-hour window."
+                    },
+                    "user_onc_token": {
+                        "type": "string",
+                        "description": "User's ONC API access token."
+                    }
+                },
+                "required": ["date_str", "user_onc_token"]
+            },
+        },
+    },
     {
         "type": "function",
         "function": {
@@ -482,6 +512,31 @@ toolDescriptions = [
                     # }
                 },
                 "required": ["date_from_str", "date_to_str"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "plot_monthly_water_depth",
+            "description": (
+            "Retrieve and plot water depth readings for Cambridge Bay over a specified month using CTD sensor data. "
+            "This function queries Ocean Networks Canada's scalar data API for the 'depth' property and returns a time series plot "
+            "along with raw timestamps and depth values. The plot is generated as a Matplotlib figure."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "month_str": {
+                        "type": "string",
+                        "description": "Month in YYYY-MM format (e.g., '2025-07') representing the month to retrieve water depth data for."
+                    },
+                    "user_onc_token": {
+                        "type": "string",
+                        "description": "User's ONC API access token."
+                    }
+                },
+                "required": ["month_str", "user_onc_token"]
             },
         },
     },

--- a/LLM/core.py
+++ b/LLM/core.py
@@ -22,8 +22,10 @@ from LLM.tools_sprint2 import (
     get_daily_air_temperature_stats_cambridge_bay,
     get_ice_thickness,
     get_oxygen_data_24h,
-    # get_ship_noise_acoustic_for_date,
+    get_ship_noise_acoustic_for_date,
     get_wind_speed_at_timestamp,
+    plot_spectrogram_for_date,
+    plot_monthly_water_depth,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,9 +47,11 @@ class LLM:
             "generate_download_codes": generate_download_codes,
             "get_daily_air_temperature_stats_cambridge_bay": get_daily_air_temperature_stats_cambridge_bay,
             "get_oxygen_data_24h": get_oxygen_data_24h,
-            # "get_ship_noise_acoustic_for_date": get_ship_noise_acoustic_for_date,
+            "get_ship_noise_acoustic_for_date": get_ship_noise_acoustic_for_date,
             "get_wind_speed_at_timestamp": get_wind_speed_at_timestamp,
             "get_ice_thickness": get_ice_thickness,
+            "plot_spectrogram_for_date": plot_spectrogram_for_date,
+            "plot_monthly_water_depth": plot_monthly_water_depth,
         }
 
     async def run_conversation(


### PR DESCRIPTION
Added tool descriptions. Changed plot_spectrogram_for_date to use dataProductDelivery endpoint. plot_monthly_water_depth is same as water depth charts don't appear to be an available data product. This branch is behind main so will have to address merge conflicts.