### PR TITLE
Added rules to the LLM to improve sprint 3 queries

### DIFF
--- a/LLM/Constants/tool_descriptions.py
+++ b/LLM/Constants/tool_descriptions.py
@@ -16,23 +16,23 @@ toolDescriptions = [
     #         },
     #     },
     # },
-    {
-        "type": "function",
-        "function": {
-            "name": "get_properties_at_cambridge_bay",
-            "description": "Get a list of properties available at Cambridge Bay. The function returns a list of dictionaries. Each Item in the list includes:\n        - description (str): Description of the property. The description may have a colon in it.\n        - propertyCode (str): Property Code of the property\n",
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    # "user_onc_token": {
-                    #     "type": "string",
-                    #     "description": "User's ONC token for API access. This is required to access the data.",
-                    # }
-                },
-            },
-            "required": [],
-        },
-    },
+    # {
+    #     "type": "function",
+    #     "function": {
+    #         "name": "get_properties_at_cambridge_bay",
+    #         "description": "Get a list of properties available at Cambridge Bay. The function returns a list of dictionaries. Each Item in the list includes:\n        - description (str): Description of the property. The description may have a colon in it.\n        - propertyCode (str): Property Code of the property\n",
+    #         "parameters": {
+    #             "type": "object",
+    #             "properties": {
+    #                 # "user_onc_token": {
+    #                 #     "type": "string",
+    #                 #     "description": "User's ONC token for API access. This is required to access the data.",
+    #                 # }
+    #             },
+    #         },
+    #         "required": [],
+    #     },
+    # },
     {
         "type": "function",
         "function": {

--- a/LLM/core.py
+++ b/LLM/core.py
@@ -16,7 +16,7 @@ from LLM.tools_sprint1 import (
     # get_time_range_of_available_data,
     get_daily_sea_temperature_stats_cambridge_bay,
     get_deployed_devices_over_time_interval,
-    get_properties_at_cambridge_bay,
+    # get_properties_at_cambridge_bay,
 )
 from LLM.tools_sprint2 import (
     get_daily_air_temperature_stats_cambridge_bay,
@@ -38,7 +38,7 @@ class LLM:
         self.model = env.get_model()
         self.RAG_instance: RAG = RAG_instance or RAG(env=self.env)
         self.available_functions = {
-            "get_properties_at_cambridge_bay": get_properties_at_cambridge_bay,
+            # "get_properties_at_cambridge_bay": get_properties_at_cambridge_bay,
             "get_daily_sea_temperature_stats_cambridge_bay": get_daily_sea_temperature_stats_cambridge_bay,
             "get_deployed_devices_over_time_interval": get_deployed_devices_over_time_interval,
             "get_active_instruments_at_cambridge_bay": get_active_instruments_at_cambridge_bay,
@@ -108,9 +108,13 @@ class LLM:
 
                 You may use tools when required to answer user questions. Do not describe what you *will* do — only use tools if needed.
 
+                You MUST explicitly include the name “Cambridge Bay” in your response whenever tool results are based on data from that location. Do not use vague phrases like “the Arctic” or “polar regions.” You must also clearly state the date range used in the tool query (e.g., dateFrom and dateTo). If the dateFrom and dateTo values fall on the same day, say that the data was sampled on that day rather than referring to a date range. 
+
                 When a tool is used, do not guess or assume what it might return. Do not speculate or reason beyond the returned result. However, you may output the tool’s result in your response and format it clearly for the user, as long as you do not add new interpretations or steps.
 
                 You are NEVER required to generate code in any language.
+
+                NEVER use a dateFrom or dateTo value that is in the future.
 
                 Do NOT add follow-up suggestions, guesses, or recommendations.
 
@@ -335,7 +339,11 @@ class LLM:
 
                     When a tool is used, do not guess or assume what it might return. Do not speculate or reason beyond the returned result. However, you may output the tool’s result in your response and format it clearly for the user, as long as you do not add new interpretations or steps.
 
+                    You MUST explicitly include the name “Cambridge Bay” in your response whenever tool results are based on data from that location. Do not use vague phrases like “the Arctic” or “polar regions.” You must also clearly state the date range used in the tool query (e.g., dateFrom and dateTo). If the dateFrom and dateTo values fall on the same day, say that the data was sampled on that day rather than referring to a date range.
+
                     You are NEVER required to generate code in any language.
+
+                    NEVER use a dateFrom or dateTo value that is in the future.
 
                     Do NOT add follow-up suggestions, guesses, or recommendations.
 

--- a/backend-api/src/admin/router.py
+++ b/backend-api/src/admin/router.py
@@ -43,15 +43,13 @@ async def create_admin_user(
     return await create_new_user(new_admin, db, is_admin=True)
 
 
-@router.get("/users", response_model=List[UserOut])
+@router.get("/users", response_model=list[auth_schemas.UserOut])
 async def list_admin_users(
     _: Annotated[auth_models.User, Depends(get_admin_user)],
     db: Annotated[AsyncSession, Depends(get_db_session)],
-) -> List[UserOut]:
+) -> list[auth_schemas.UserOut]:
     """List all admin users"""
-    result = await db.execute(
-        select(auth_models.User).where(auth_models.User.is_admin == True)
-    )
+    result = await db.execute(select(auth_models.User).where(auth_models.User.is_admin))
     return result.scalars().all()
 
 


### PR DESCRIPTION
I have regression tested and everything appears to work as intended. These changes make for much better responses for all of the sprint 3 queries, most of which require specific time ranges and return information about cambridge bay.