### PR TITLE
Add Libgl1 to Dockerfile so VM can run image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     g++ \
     libomp-dev \
     python3-dev \
+    libgl1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .


### PR DESCRIPTION
I added libgl1 to Dockerfile to fix libGL.so.1 error with opencv on the UVic VM.