### PR TITLE
Seperate vectordb collections

### DIFF
--- a/LLM/Environment.py
+++ b/LLM/Environment.py
@@ -18,6 +18,10 @@ class Environment:
         self.client = Groq(api_key=os.getenv("GROQ_API_KEY"))
         self.qdrant_url = os.getenv("QDRANT_URL")
         self.collection_name = os.getenv("QDRANT_COLLECTION_NAME")
+        self.general_collection_name = os.getenv("QDRANT_GENERAL_COLLECTION_NAME")
+        self.function_calling_collection_name = os.getenv(
+            "QDRANT_FUNCTION_CALLING_COLLECTION_NAME"
+        )
         self.qdrant_api_key = os.getenv("QDRANT_API_KEY")
 
     def get_onc_token(self):
@@ -35,8 +39,11 @@ class Environment:
     def get_qdrant_url(self):
         return self.qdrant_url
 
-    def get_collection_name(self):
-        return self.collection_name
+    def get_general_collection_name(self):
+        return self.general_collection_name
+
+    def get_function_calling_collection_name(self):
+        return self.function_calling_collection_name
 
     def get_qdrant_api_key(self):
         return self.qdrant_api_key

--- a/LLM/RAG.py
+++ b/LLM/RAG.py
@@ -74,13 +74,16 @@ class RAG:
         self.compressor = CrossEncoderReranker(model=self.model, top_n=15)
 
     def get_documents(self, question: str):
+        query_embedding = self.embedding.embed_query(question)
         general_results = self.get_documents_helper(
+            query_embedding,
             question,
             self.general_collection_name,
             documentFilteringType.Score,
             min_score=0.4,
         )
         function_calling_results = self.get_documents_helper(
+            query_embedding,
             question,
             self.function_calling_collection_name,
             documentFilteringType.MaxDocuments,
@@ -91,13 +94,13 @@ class RAG:
 
     def get_documents_helper(
         self,
+        query_embedding,
         question: str,
         collection_name: str,
         filtering_type: documentFilteringType,
         min_score: float = 0.4,
         max_returns: int = 1,
     ):
-        query_embedding = self.embedding.embed_query(question)
         search_results = self.qdrant_client.search(
             collection_name=collection_name,
             query_vector=query_embedding,


### PR DESCRIPTION
A demo version of a redesign that seperate's our VectorDB into 2 collections. One for data download code information and another for general information. This is intended to reduce token usage in LLM calls and improve response times.  