### PR TITLE
Vector db auto upload

### DIFF
--- a/LLM/vectorDBUpload.py
+++ b/LLM/vectorDBUpload.py
@@ -372,10 +372,6 @@ def upload_to_vector_db(resultsList: list, qdrant: QdrantClientWrapper):
         collection_name=qdrant.collection_name, points=points
     )
 
-
-def sayHello():
-    print(f"[{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] Hello from scheduled_vector_db_update!")
-
 #Function gets called through APScheduler jobs to delete existing "ONC OCEANS 3.0 API" points and reupload with today's date
 def vdb_auto_upload(app_state):
 

--- a/LLM/vectorDBUpload.py
+++ b/LLM/vectorDBUpload.py
@@ -19,7 +19,7 @@ from unstructured.partition.pdf import partition_pdf
 from LLM.RAG import JinaEmbeddings, QdrantClientWrapper
 
 import datetime
-from qdrant_client.http.models import FieldCondition, Filter, MatchValue
+from qdrant_client.http.models import FieldCondition, Filter, MatchValue, PayloadSchemaType
 
 """
 Series of functions to preprocess PDF files, extract structured text chunks,
@@ -380,6 +380,13 @@ def sayHello():
 def vdb_auto_upload(app_state):
 
     qdrant_client_wrapper = app_state.rag.qdrant_client_wrapper
+
+    #Create a payload index for "source" field (can't filter without this)
+    qdrant_client_wrapper.qdrant_client.create_payload_index(
+        collection_name=qdrant_client_wrapper.collection_name,
+        field_name="source",
+        field_schema=PayloadSchemaType.KEYWORD,
+    )
 
     filter_condition = Filter(
         must=[FieldCondition(key="source", match=MatchValue(value="ONC OCEANS 3.0 API"))]

--- a/backend-api/src/lifespan.py
+++ b/backend-api/src/lifespan.py
@@ -10,6 +10,9 @@ from src.database import DatabaseSessionManager
 from src.logger import logger
 from src.settings import get_settings
 
+from LLM.vectorDBUpload import vdb_auto_upload
+from apscheduler.schedulers.background import BackgroundScheduler # Import APScheduler
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -40,6 +43,21 @@ async def lifespan(app: FastAPI):
         logger.info("Getting RAG instance...")
         app.state.rag = app.state.llm.RAG_instance
         logger.info("RAG instance initialized successfully.")
+        
+        logger.info("Initializing APScheduler...")
+        scheduler = BackgroundScheduler()
+
+        scheduler.add_job(
+            vdb_auto_upload,
+            'interval',
+            hours = 24,
+            id='vdb auto upload',
+            args=[app.state], 
+            
+        )
+
+        scheduler.start()
+        logger.info("APScheduler started in the background.")
 
     except Exception as e:
         logger.error(f"Startup failed with error: {str(e)}")

--- a/backend-api/src/lifespan.py
+++ b/backend-api/src/lifespan.py
@@ -43,10 +43,8 @@ async def lifespan(app: FastAPI):
         logger.info("Getting RAG instance...")
         app.state.rag = app.state.llm.RAG_instance
         logger.info("RAG instance initialized successfully.")
-        
-        logger.info("Initializing APScheduler...")
-        scheduler = BackgroundScheduler()
 
+        scheduler = BackgroundScheduler()
         scheduler.add_job(
             vdb_auto_upload,
             'interval',
@@ -55,9 +53,8 @@ async def lifespan(app: FastAPI):
             args=[app.state], 
             
         )
-
         scheduler.start()
-        logger.info("APScheduler started in the background.")
+        logger.info("Started vector database auto upload job every 24 hours")
 
     except Exception as e:
         logger.error(f"Startup failed with error: {str(e)}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ aiosqlite==0.21.0
 alembic==1.16.4
 annotated-types==0.7.0
 anyio==4.9.0
+asgi-lifespan
 asttokens==3.0.0
 asyncpg==0.30.0
 attrs==25.3.0
@@ -97,7 +98,6 @@ pydantic-settings==2.9.1
 pydantic_core==2.33.2
 Pygments==2.19.1
 PyJWT==2.10.1
-pymupdf==1.23.9
 pytest==8.4.0
 pytest-asyncio==1.0.0
 python-dateutil==2.9.0.post0
@@ -149,3 +149,4 @@ websockets==15.0.1
 xxhash==3.5.0
 yarl==1.20.0
 zstandard==0.23.0
+APScheduler==3.10.4


### PR DESCRIPTION
In Lifespan.py we schedule a job (using APScheduler) that runs every 24 hours (first run happens 24 after application starts)

Scheduled job runs vdb_auto_upload in VectorDBUpload.py
- Creates payload index for filtering on "source" field
- Filters and deletes qdrant datapoints on source = "ONC OCEANS 3.0 API"
- Calls ONC API for device deployments, if "*dateTo*" field is None, we set to current date
- Uploads new points