### PR TITLE
feedback loop integration

### DIFF
--- a/LLM/Environment.py
+++ b/LLM/Environment.py
@@ -18,6 +18,7 @@ class Environment:
         self.client = Groq(api_key=os.getenv("GROQ_API_KEY"))
         self.qdrant_url = os.getenv("QDRANT_URL")
         self.collection_name = os.getenv("QDRANT_COLLECTION_NAME")
+        self.QA_collection_name = os.getenv("QDRANT_QA_COLLECTION_NAME")
         self.general_collection_name = os.getenv("QDRANT_GENERAL_COLLECTION_NAME")
         self.function_calling_collection_name = os.getenv(
             "QDRANT_FUNCTION_CALLING_COLLECTION_NAME"
@@ -38,6 +39,9 @@ class Environment:
 
     def get_qdrant_url(self):
         return self.qdrant_url
+    
+    def get_QA_collection_name(self):
+        return self.QA_collection_name
 
     def get_general_collection_name(self):
         return self.general_collection_name

--- a/LLM/Environment.py
+++ b/LLM/Environment.py
@@ -17,7 +17,7 @@ class Environment:
         self.model = "llama-3.3-70b-versatile"
         self.client = Groq(api_key=os.getenv("GROQ_API_KEY"))
         self.qdrant_url = os.getenv("QDRANT_URL")
-        self.collection_name = os.getenv("QDRANT_COLLECTION_NAME")
+        self.knowledge_collection_name = os.getenv("QDRANT_COLLECTION_NAME")
         self.QA_collection_name = os.getenv("QDRANT_QA_COLLECTION_NAME")
         self.general_collection_name = os.getenv("QDRANT_GENERAL_COLLECTION_NAME")
         self.function_calling_collection_name = os.getenv(

--- a/LLM/RAG.py
+++ b/LLM/RAG.py
@@ -146,7 +146,7 @@ class RAG:
         df = df[:max_returns]
         return df
 
-
+    #Retrieve Q&A pairs for feedback loop
     def get_qa_docs( 
         self,
         question:str):

--- a/LLM/RAG.py
+++ b/LLM/RAG.py
@@ -6,9 +6,9 @@ from langchain_community.vectorstores import Qdrant
 from langchain_core.documents import Document
 from qdrant_client import QdrantClient
 from sentence_transformers import SentenceTransformer
-
+from qdrant_client.http.models import PointStruct
 from LLM.Environment import Environment
-
+from uuid import uuid4
 
 class JinaEmbeddings(Embeddings):
     def __init__(self, task="retrieval.passage"):
@@ -37,6 +37,7 @@ class QdrantClientWrapper:
         self.function_calling_collection_name = (
             env.get_function_calling_collection_name()
         )
+        self.QA_collection_name = env.get_QA_collection_name()
 
 
 class RAG:
@@ -49,6 +50,9 @@ class RAG:
 
         self.general_collection_name = (
             self.qdrant_client_wrapper.general_collection_name
+        )
+        self.QA_collection_name = (
+            self.qdrant_client_wrapper.QA_collection_name
         )
         self.function_calling_collection_name = (
             self.qdrant_client_wrapper.function_calling_collection_name
@@ -141,3 +145,63 @@ class RAG:
         df = pd.DataFrame({"contents": compression_contents, "sources": sources})
         df = df[:max_returns]
         return df
+
+
+    def get_qa_docs( 
+        self,
+        question:str):
+        search_results = self.qdrant_client.search(
+            collection_name=self.QA_collection_name,
+            query_vector=self.embedding.embed_query(question),
+            limit=5,
+            with_payload=True,
+            with_vectors=False,
+        )
+
+        qa_docs = []
+        for hit in search_results:
+            qa_docs.append(
+                Document(
+                    page_content=hit.payload["text"],
+                    metadata={"score": hit.score}
+                )
+            )
+
+        df_qa = pd.DataFrame({"contents":qa_docs})
+        return df_qa
+    
+    #Uploads new Q&A pair to Qdrant Q&A collection
+    #When we receive a "thumbs-up" feedback on an LLM response, backend-api/src/LLM/service.py calls this function
+    async def upload_new_qa(self, qa_pair: dict):
+        current_qa_id = uuid4().hex
+
+        # Determine the actual text content for embedding and payload
+        actual_text_content = qa_pair["text"]
+        if isinstance(actual_text_content, dict) and "response" in actual_text_content:
+            actual_text_content = actual_text_content["response"]
+        elif not isinstance(actual_text_content, str):
+
+            actual_text_content = str(actual_text_content)
+
+        QA_text = f"Question: {qa_pair['original_question']} Answer: {actual_text_content}"
+
+        # embedding_vector = self.Qdrant_model.encode(QA_text)
+        embedding_vector = self.embedding.embed_documents([QA_text])[0]
+
+        item_payload = {
+            "text": actual_text_content,
+            "original_question": qa_pair["original_question"],
+        }
+        
+        # Create a PointStruct for the new data point
+        new_point = PointStruct(
+            id=current_qa_id,
+            vector=embedding_vector,
+            payload=item_payload
+        )
+        # Upload the new point to Qdrant collection
+        self.qdrant_client.upsert(
+            collection_name=self.QA_collection_name,
+            points=[new_point]  # upsert expects a list of points
+        )
+        

--- a/LLM/core.py
+++ b/LLM/core.py
@@ -101,13 +101,8 @@ class LLM:
                     qa_reference = qa_docs.to_string(index=False)
             else:
                 qa_reference = str(qa_docs)
+            styling_prompt = ""
 
-            messages = [
-                {
-                    "role": "system",
-                    "content": startingPrompt,
-                }
-            ]
             if qa_reference:
                 styling_prompt = f"""
                 The following are examples of question-answer pairs that represent the desired style, tone, and preferred phrasing for your responses.
@@ -120,17 +115,23 @@ class LLM:
                 Examples for styling guidance:
                 {qa_reference}
                 """
-                messages.append({"role": "system", "content": styling_prompt})
 
-            messages.extend([
-                {"role": "assistant", "content": vector_content},
+            messages = [
+                {
+                    "role": "system",
+                    "content": startingPrompt,
+                },
+                {
+                    "role":"system",
+                    "content": styling_prompt,
+                },
+                 {"role": "assistant", "content": vector_content},
                 *chat_history,
                 {
                     "role": "user",
                     "content": user_prompt,
                 },
-            ])
-
+            ]
             response = self.client.chat.completions.create(
                 model=self.model,  # LLM to use
                 messages=messages,  # Includes Conversation history
@@ -221,6 +222,10 @@ class LLM:
                     {
                         "role": "system",
                         "content": secondLLMCallStartingPrompt,
+                    },
+                    {
+                        "role":"system",
+                        "content":styling_prompt, #from Q&A docs
                     },
                     {"role": "assistant", "content": vector_content},
                     *toolMessages,  # Add tool messages to the conversation

--- a/LLM/core.py
+++ b/LLM/core.py
@@ -105,13 +105,9 @@ class LLM:
 
             if qa_reference:
                 styling_prompt = f"""
-                The following are examples of question-answer pairs that represent the desired style, tone, and preferred phrasing for your responses.
-                These examples are **CRUCIALLY ONLY for stylistic guidance** and do **NOT** represent current factual information, data availability, tool usage, or required parameters.
-                You **MUST NOT** use these examples as factual context or directly answer from them.
-                Instead, analyze them **solely** to understand the preferred phrasing, level of detail, and overall stylistic conventions
-                when formulating your own answers based on other retrieved information and tool outputs.
-                **Absolutely DO NOT** initiate any tool calls based on the content or patterns found within these styling examples.
-
+                The following responses are ONLY used for styling and tone references.
+                DO NOT use the information and data in these responses to generate your own responses.
+                DO NOT take data from the examples for your own response.
                 Examples for styling guidance:
                 {qa_reference}
                 """

--- a/backend-api/src/llm/router.py
+++ b/backend-api/src/llm/router.py
@@ -88,6 +88,7 @@ async def submit_feedback(
     feedback: Feedback,
     current_user: Annotated[UserOut, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db_session)],
+    request:Request,
 ) -> Message:
     """Update the feedback in the Message model"""
-    return await service.submit_feedback(message_id, feedback, current_user, db)
+    return await service.submit_feedback(message_id, feedback, current_user, db,request)


### PR DESCRIPTION
Made a new PR because the old one was really behind main and had some issues with the response time

Added upload_message_to_qdrant function in service.py which gets called when user gives a "thumbs-up" rating

- Takes the question asked (user prompt) and its immediate response as Q&A pair
- Calls upload_new_qa function in RAG to upload Q&A pair to qdrant
- Only "thumbs-up" responses will be uploaded
- Added functionality in RAG.py that pulls datapoints from Q&A section, then passes it on to LLM for reference

LLM will read the Q&A datapoints and use for styling and NOT context/data

Tested with sprint 1 & 2 regression queries, results/responses are the same

