### PR TITLE
patch onc token validation in test configuration

### DIFF
--- a/backend-api/test/test_auth.py
+++ b/backend-api/test/test_auth.py
@@ -1,7 +1,5 @@
-from unittest.mock import AsyncMock, patch
-
 import pytest
-from fastapi import HTTPException, status
+from fastapi import status
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,7 +8,6 @@ from src.auth.service import get_password_hash, get_user
 from src.settings import get_settings
 
 
-@patch("src.auth.service.validate_onc_token")
 class TestRegistration:
     def _create_user_request(
         self,
@@ -36,11 +33,9 @@ class TestRegistration:
 
     @pytest.mark.asyncio
     async def test_register_new_user(
-        self, mock_validate: AsyncMock, client: AsyncClient, async_session: AsyncSession
+        self, client: AsyncClient, async_session: AsyncSession
     ):
         """Test registering a new user"""
-
-        mock_validate.return_value = None  # mock valid onc token
 
         new_user = self._create_user_request(username="lebron", password="cavs")
 
@@ -59,12 +54,9 @@ class TestRegistration:
 
     @pytest.mark.asyncio
     async def test_register_existing_user(
-        self, mock_validate: AsyncMock, client: AsyncClient, async_session: AsyncSession
+        self, client: AsyncClient, async_session: AsyncSession
     ):
         """Test adding a user that already exists"""
-
-        # Mock the ONC token validation
-        mock_validate.return_value = None  # mock valid onc token
 
         # Add user that should exist in db first
         existing_user = self._create_user_model(username="lebron", password="cavs")
@@ -85,15 +77,11 @@ class TestRegistration:
 
     @pytest.mark.asyncio
     async def test_register_invalid_onc_token(
-        self, mock_validate: AsyncMock, client: AsyncClient, async_session: AsyncSession
+        self, client: AsyncClient, async_session: AsyncSession
     ):
         """Test registering user with invalid onc token"""
         invalid = self._create_user_request(
             username="lebron", password="cavs", token="invalid_token"
-        )
-
-        mock_validate.side_effect = HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid ONC token"
         )
 
         response = await client.post("/auth/register", json=invalid.model_dump())


### PR DESCRIPTION
I forgot to add the mock to some other tests on the last "flaky test" pr, so the github action fails still happened. Instead of adding the mock to more functions, I just made a global mock that is automatically used. Now there should never be a call to onc when testing.

I also removed some environment variable set up in the conftest since it wasn't being used anyways.